### PR TITLE
Fix step count so final form step renders

### DIFF
--- a/src/components/app-states/ProgressBar.tsx
+++ b/src/components/app-states/ProgressBar.tsx
@@ -8,10 +8,10 @@ interface ProgressBarProps {
   totalSteps?: number;
 }
 
-const ProgressBar: React.FC<ProgressBarProps> = ({ 
-  progress, 
-  step = 0, 
-  totalSteps = 32 
+const ProgressBar: React.FC<ProgressBarProps> = ({
+  progress,
+  step = 0,
+  totalSteps = 33
 }) => {
   const [prevProgress, setPrevProgress] = useState(progress);
 

--- a/src/contexts/SurveyContext.tsx
+++ b/src/contexts/SurveyContext.tsx
@@ -24,8 +24,8 @@ interface SurveyProviderProps {
 }
 
 export const SurveyProvider: React.FC<SurveyProviderProps> = ({ children, initialStep }) => {
-  // Updated to 32 steps with correct flow (including AllergiesStep)
-  const totalSteps = 32;
+  // Updated to 33 steps with correct flow (including StartCommitmentStep)
+  const totalSteps = 33;
   
   // Use our custom hooks
   const { formData, setFormData, updateFormData } = useSurveyForm();


### PR DESCRIPTION
## Summary
- correct step count in provider and progress bar to 33 so the StartCommitment step appears

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4d4716d88327bcf6153eebab95f6